### PR TITLE
Added command to create the tmp directory

### DIFF
--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,6 +2,7 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
+      execute :mkdir, '-p', release_path.join('tmp')
       execute :touch, release_path.join('tmp/restart.txt')
     end
   end


### PR DESCRIPTION
The gem tries to touch the tmp/restart.txt file, but if the tmp folder does not exists the command fails and the restart never happens.

In fact it fails ugly.
