### PR TITLE
Add ability to deploy with turbocaching disabled 

### DIFF
--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,8 +2,8 @@ namespace :deploy do
   desc 'Restart application'
   task :hard_restart do
     on roles fetch :passenger_roles do
-      stop
-      start
+      invoke 'deploy:stop'
+      invoke 'deploy:start'
     end
   end
 

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,8 +2,8 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      stop
-      start
+      :stop
+      :start
     end
   end
 

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -42,11 +42,10 @@ end
 
 namespace :load do
   task :defaults do
-    set :passenger_cmd, 'passenger'
-    set :passenger_port, 9090
     set :passenger_roles, :app
     set :passenger_restart_runner, :sequence
     set :passenger_restart_wait, 5
     set :passenger_restart_limit, 2
+    set :passenger_turbocache_enabled, true
   end
 end

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -23,7 +23,9 @@ namespace :deploy do
   task :start do
     on roles fetch :passenger_roles do
       within current_path do
-        execute :bundle, :exec, fetch(:passenger_cmd), :start, '-e', fetch(:rails_env), '-p', fetch(:passenger_port), '-d', '--disable-turbocaching'
+        turbocache_flag = fetch(:passenger_turbocache_enabled) ? nil : '--disable-turbocaching'
+
+        execute :bundle, :exec, fetch(:passenger_cmd), :start, '-e', fetch(:rails_env), '-p', fetch(:passenger_port), '-d', turbocache_flag
       end
     end
   end

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,8 +2,8 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      execute :mkdir, '-p', release_path.join('tmp')
-      execute :touch, release_path.join('tmp/restart.txt')
+      execute :stop
+      execute :start
     end
   end
   after :publishing, :restart

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -16,6 +16,7 @@ namespace :deploy do
   end
 
   desc 'Start up application'
+  Rake::Task['start'].clear_actions
   task :start do
     on roles fetch :passenger_roles do
       within current_path do
@@ -25,6 +26,7 @@ namespace :deploy do
   end
 
   desc 'Stop the application'
+  Rake::Task['stop'].clear_actions
   task :stop do
     on roles fetch :passenger_roles do
       within current_path do

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,8 +2,8 @@ namespace :deploy do
   desc 'Restart application'
   task :hard_restart do
     on roles fetch :passenger_roles do
-      deploy:stop
-      deploy:start
+      :stop
+      :start
     end
   end
 

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -1,9 +1,9 @@
 namespace :deploy do
   desc 'Restart application'
-  task :restart do
-    on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      :stop
-      :start
+  task :hard_restart do
+    on roles fetch :passenger_roles do
+      deploy:stop
+      deploy:start
     end
   end
 

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,7 +2,7 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      if execute "[ -s tmp/pids/passenger.#{fetch(:passenger_port)}.pid ]" 
+      if test "[ -s tmp/pids/passenger.#{fetch(:passenger_port)}.pid ]" == true
         execute :mkdir, '-p', release_path.join('tmp')
         execute :touch, release_path.join('tmp/restart.txt')
       else

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,7 +2,7 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      if test '-s', "tmp/pids/passenger.#{fetch(:passenger_port)}.pid"
+      if test "[ -s tmp/pids/passenger.#{fetch(:passenger_port)}.pid ]"
         execute :mkdir, '-p', release_path.join('tmp')
         execute :touch, release_path.join('tmp/restart.txt')
       else

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,13 +2,11 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      within current_path do
-        if test "[ -s tmp/pids/passenger.#{fetch(:passenger_port)}.pid ]"
-          execute :mkdir, '-p', release_path.join('tmp')
-          execute :touch, release_path.join('tmp/restart.txt')
-        else
-          invoke 'deploy:start'
-        end
+      if test "[ -s #{release_path}/tmp/pids/passenger.#{fetch(:passenger_port)}.pid ]"
+        execute :mkdir, '-p', release_path.join('tmp')
+        execute :touch, release_path.join('tmp/restart.txt')
+      else
+        invoke 'deploy:start'
       end
     end
   end

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,8 +2,8 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      execute :stop
-      execute :start
+      execute :bundle, :exec, deploy:stop
+      execute :bundle, :exec, deploy:start
     end
   end
   after :publishing, :restart

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,7 +2,7 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      if test "[ -s tmp/pids/passenger.#{fetch(:passenger_port)}.pid ]" == true
+      if test "[ -s tmp/pids/passenger.#{fetch(:passenger_port)}.pid ]"
         execute :mkdir, '-p', release_path.join('tmp')
         execute :touch, release_path.join('tmp/restart.txt')
       else

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,15 +2,34 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      execute :bundle, :exec, deploy:stop
-      execute :bundle, :exec, deploy:start
+      execute :stop
+      execute :start
     end
   end
+
+  task :start do
+    on roles fetch :passenger_roles do
+      within current_path do
+        execute :bundle, :exec, fetch(:passenger_cmd), :start, '-e', fetch(:rails_env), '-p', fetch(:passenger_port), '-d', '--disable-turbocaching'
+      end
+    end
+  end
+
+  task :stop do
+    on roles fetch :passenger_roles do
+      within current_path do
+        execute :bundle, :exec, fetch(:passenger_cmd), :stop, '-p', fetch(:passenger_port)
+      end
+    end
+  end
+
   after :publishing, :restart
 end
 
 namespace :load do
   task :defaults do
+    set :passenger_cmd, 'passenger'
+    set :passenger_port, 9090
     set :passenger_roles, :app
     set :passenger_restart_runner, :sequence
     set :passenger_restart_wait, 5

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -1,5 +1,13 @@
 namespace :deploy do
   desc 'Restart application'
+  task :restart do
+    on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
+      execute :mkdir, '-p', release_path.join('tmp')
+      execute :touch, release_path.join('tmp/restart.txt')
+    end
+  end
+
+  desc 'Hard restart application'
   task :hard_restart do
     on roles fetch :passenger_roles do
       invoke 'deploy:stop'
@@ -7,6 +15,7 @@ namespace :deploy do
     end
   end
 
+  desc 'Start up application'
   task :start do
     on roles fetch :passenger_roles do
       within current_path do
@@ -15,6 +24,7 @@ namespace :deploy do
     end
   end
 
+  desc 'Stop the application'
   task :stop do
     on roles fetch :passenger_roles do
       within current_path do

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,8 +2,8 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      execute :stop
-      execute :start
+      stop
+      start
     end
   end
 

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,8 +2,12 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      execute :mkdir, '-p', release_path.join('tmp')
-      execute :touch, release_path.join('tmp/restart.txt')
+      if execute "[ -s tmp/pids/passenger.#{:passenger_port}.pid]" 
+        execute :mkdir, '-p', release_path.join('tmp')
+        execute :touch, release_path.join('tmp/restart.txt')
+      else
+        invoke 'deploy:start'
+      end
     end
   end
 

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,7 +2,7 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      if execute "[ -s tmp/pids/passenger.#{:passenger_port}.pid]" 
+      if execute "[ -s tmp/pids/passenger.#{fetch(:passenger_port)}.pid]" 
         execute :mkdir, '-p', release_path.join('tmp')
         execute :touch, release_path.join('tmp/restart.txt')
       else

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,7 +2,7 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      if execute "[ -s tmp/pids/passenger.#{fetch(:passenger_port)}.pid]" 
+      if execute "[ -s tmp/pids/passenger.#{fetch(:passenger_port)}.pid ]" 
         execute :mkdir, '-p', release_path.join('tmp')
         execute :touch, release_path.join('tmp/restart.txt')
       else

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,7 +2,7 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      if test '-s' "tmp/pids/passenger.#{fetch(:passenger_port)}.pid"
+      if test '-s', "tmp/pids/passenger.#{fetch(:passenger_port)}.pid"
         execute :mkdir, '-p', release_path.join('tmp')
         execute :touch, release_path.join('tmp/restart.txt')
       else

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,7 +2,7 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      if test "[ -s tmp/pids/passenger.#{fetch(:passenger_port)}.pid ]"
+      if test '-s' "tmp/pids/passenger.#{fetch(:passenger_port)}.pid"
         execute :mkdir, '-p', release_path.join('tmp')
         execute :touch, release_path.join('tmp/restart.txt')
       else

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,11 +2,13 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
-      if test "[ -s tmp/pids/passenger.#{fetch(:passenger_port)}.pid ]"
-        execute :mkdir, '-p', release_path.join('tmp')
-        execute :touch, release_path.join('tmp/restart.txt')
-      else
-        invoke 'deploy:start'
+      within current_path do
+        if test "[ -s tmp/pids/passenger.#{fetch(:passenger_port)}.pid ]"
+          execute :mkdir, '-p', release_path.join('tmp')
+          execute :touch, release_path.join('tmp/restart.txt')
+        else
+          invoke 'deploy:start'
+        end
       end
     end
   end

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -16,7 +16,6 @@ namespace :deploy do
   end
 
   desc 'Start up application'
-  Rake::Task['start'].clear_actions
   task :start do
     on roles fetch :passenger_roles do
       within current_path do
@@ -26,7 +25,6 @@ namespace :deploy do
   end
 
   desc 'Stop the application'
-  Rake::Task['stop'].clear_actions
   task :stop do
     on roles fetch :passenger_roles do
       within current_path do

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -2,8 +2,8 @@ namespace :deploy do
   desc 'Restart application'
   task :hard_restart do
     on roles fetch :passenger_roles do
-      :stop
-      :start
+      stop
+      start
     end
   end
 


### PR DESCRIPTION
This PR adds the following functionality to the Capistrano-Passenger gem:
1. Ability to deploy an app with Passenger's turbocache disabled.
2. Ability to hard restart Passenger on deploy. (i.e. cap production deploy:hard_restart)
3. On deploy:restart, execute the tmp/restart.txt strategy if Passenger is running. If Passenger is not running, start it up instead of executing the restart.txt strategy. Since deploy:restart is run after the publishing hook, this ensures that a Passenger server is running after a deploy (barring extraneous circumstances). 

In the defaults namespace, there is a new option called passenger_turbocache_enabled, and it defaults to true. A user can set the passenger_turbocache_enabled option to false within their own deploy.rb file.
