### PR TITLE
use "passenger-config restart-app" to restart app when available

### DIFF
--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -3,9 +3,9 @@ namespace :passenger do
   task :restart do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
       with fetch(:passenger_environment_variables) do
-        passenger_version = capture(:passenger, '-v').match(/\APhusion Passenger version (.*)$/)[1].to_i
+        passenger_version = capture(:passenger, '-v').match(/\APhusion Passenger version (.*)$/)[1]
 
-        if passenger_version > 4
+        if Gem::Version.new(passenger_version) >= Gem::Version.new('4.0.33')
           restart_with_sudo = fetch(:passenger_restart_with_sudo) ? :sudo : nil
           arguments = [restart_with_sudo, *fetch(:passenger_restart_command).split(" ").collect(&:to_sym), fetch(:passenger_restart_options)].compact
           execute *arguments


### PR DESCRIPTION
`restart-app` is available since Passenger 4.0.33:

   http://old.blog.phusion.nl/2014/01/02/phusion-passenger-4-0-33-released/

The version check uses the default version checker built into Rubygems.

This closes #11.
