### PR TITLE
use full namespace on callback to ensure resolution

### DIFF
--- a/lib/capistrano/tasks/deploy_passenger.cap
+++ b/lib/capistrano/tasks/deploy_passenger.cap
@@ -5,5 +5,5 @@ namespace :deploy do
   task :restart do
     invoke('passenger:restart')
   end
-  after :publishing, :restart
+  after :publishing, :'deploy:restart'
 end


### PR DESCRIPTION
We have had some issues resolving the task in question in our production systems. Digging into it, it seems to be easily fixed by using full namespace qualification. This is also consistent with use elsewhere in this gem.
