### PR TITLE
Allow the Passenger restart method to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ set :passenger_restart_runner, :sequence
 set :passenger_restart_wait, 5
 set :passenger_restart_limit, 2
 set :passenger_restart_with_sudo, false
+set :passenger_restart_method, :command  # if Passenger > 4, else :restart_txt
 set :passenger_environment_variables, {}
 set :passenger_restart_command, 'passenger-config restart-app'
 set :passenger_restart_options, -> { "#{deploy_to} --ignore-app-not-running" }

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -4,14 +4,19 @@ namespace :passenger do
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
       with fetch(:passenger_environment_variables) do
         passenger_version = capture(:passenger, '-v').match(/\APhusion Passenger version (.*)$/)[1].to_i
+        default_method = passenger_version > 4 ? :command : :restart_txt
+        restart_method = fetch(:passenger_restart_method, nil) || default_method
 
-        if passenger_version > 4
+        case restart_method
+        when :command
           restart_with_sudo = fetch(:passenger_restart_with_sudo) ? :sudo : nil
           arguments = [restart_with_sudo, *fetch(:passenger_restart_command).split(" ").collect(&:to_sym), fetch(:passenger_restart_options)].compact
           execute *arguments
-        else
+        when :restart_txt
           execute :mkdir, '-p', release_path.join('tmp')
           execute :touch, release_path.join('tmp/restart.txt')
+        else
+          raise ArgumentError, "Unknown restart method: #{restart_method.inspect}"
         end
       end
     end
@@ -57,6 +62,7 @@ namespace :load do
     set :passenger_restart_limit, 2
     set :passenger_restart_with_sudo, false
     set :passenger_environment_variables, {}
+    set :passenger_restart_method, nil
     set :passenger_restart_command, 'passenger-config restart-app'
     set :passenger_restart_options, -> { "#{deploy_to} --ignore-app-not-running" }
     set :passenger_rvm_ruby_version, ->{ fetch(:rvm_ruby_version) }


### PR DESCRIPTION
Previously it was hardcoded to use the `passenger-config` program if the
Passenger version is greater than 4. However, this program can have
issues on certain systems such as being unable to access the /tmp dir
with the PrivateTmp systemd configuration[1](https://code.google.com/p/phusion-passenger/issues/detail?id=1106) or requiring a privileged
user[2](https://github.com/phusion/passenger/issues/1392).

The behaviour has the same defaults as before but can be overridden by
setting the `:passenger_restart_method` setting to `:restart_txt` to use
the method before Passenger 5. Touching restart.txt is still supported
but with a 10 second (by default) polling interval.
