### PR TITLE
Grab passenger ver even it's not first line

### DIFF
--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -12,7 +12,7 @@ namespace :passenger do
       with fetch(:passenger_environment_variables) do
         within(release_path) do
           if restart_with_touch.nil?
-            passenger_version = capture(:passenger, '-v').match(/\APhusion Passenger version (.*)$/)[1]
+            passenger_version = capture(:passenger, '-v').match(/Phusion Passenger version (.*)$/)[1]
             restart_with_touch = Gem::Version.new(passenger_version) < Gem::Version.new('4.0.33')
           end
 


### PR DESCRIPTION
For https://github.com/capistrano/passenger/issues/20 , if the version info returned by `passenger -v` is not the first line, the original regular expression will return nil so that error will be raised. This might happen sometime, such as RVM might give a warning when running a command.
