### PR TITLE
Passenger Enterprise support, fix `passenger-config` not being run with 'cd #{release_path}'

### DIFF
--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -20,9 +20,17 @@ namespace :passenger do
             execute :mkdir, '-p', release_path.join('tmp')
             execute :touch, release_path.join('tmp/restart.txt')
           else
-            restart_with_sudo = fetch(:passenger_restart_with_sudo) ? :sudo : nil
-            arguments = SSHKit::Command.new(*[*fetch(:passenger_restart_command).split(" ").collect(&:to_sym), fetch(:passenger_restart_options)]).to_s
-            execute *[restart_with_sudo, arguments].compact
+            restart_command = fetch(:passenger_restart_command).split(" ").collect(&:to_sym)
+            if fetch(:passenger_restart_with_sudo)
+              command = [:sudo]
+              # We preprocess the command with SSHKit::Command to allow
+              # 'passenger-config' to be transformed with the command map.
+              command << SSHKit::Command.new(*[*restart_command, fetch(:passenger_restart_options)]).to_s
+            else
+              command = restart_command
+              command << fetch(:passenger_restart_options)
+            end
+            execute *command
           end
         end
       end

--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -12,7 +12,7 @@ namespace :passenger do
       with fetch(:passenger_environment_variables) do
         within(release_path) do
           if restart_with_touch.nil?
-            passenger_version = capture(:passenger, '-v').match(/^Phusion Passenger version (.*)$/)[1]
+            passenger_version = capture(:passenger, '-v').match(/^Phusion Passenger (Enterprise )?version (.*)$/)[2]
             restart_with_touch = Gem::Version.new(passenger_version) < Gem::Version.new('4.0.33')
           end
 


### PR DESCRIPTION
This pull request fixes two issues.
- Fixes parsing Passenger Enterprise version output.
- Fix `passenger-config` not being run with 'cd #{release_path}' if passenger_in_gemfile is true.
  
  The old method tries to obtain a command string using SSHKit::Command.new. That doesn't work so well: the `within(release_path)` rule isn't applied to the command string. As a result, Capistrano would try to run "bundle exec passenger-config" without prepending "cd #{release_path}". This new code fixes that.

Can I request a new release ASAP? I found this bug while testing the new Passenger documentation (https://www.phusionpassenger.com/library/walkthroughs/deploy/ruby/ownserver/standalone/oss/install_language_runtime.html and https://www.phusionpassenger.com/library/advanced_production/ruby_capistrano.html). I'd like to be able to add a version specifier in my example code so that users are guaranteed to get a working example.
