### PR TITLE
Fix "Directory does not exist" with sshkit >= 1.19

### DIFF
--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -10,7 +10,7 @@ namespace :passenger do
     end
     on roles(fetch(:passenger_roles)), in: fetch(:passenger_restart_runner), wait: fetch(:passenger_restart_wait), limit: fetch(:passenger_restart_limit) do
       with fetch(:passenger_environment_variables) do
-        within(fetch(:passenger_in_gemfile, false) ? release_path : "") do
+        within(fetch(:passenger_in_gemfile, false) ? release_path : capture(:pwd)) do
           if restart_with_touch.nil?
             # 'passenger -v' may output one of the following depending on the version:
             # Phusion Passenger version x.x.x


### PR DESCRIPTION
within('') fails when sshkit >= 1.19.

Fixes #48 

(CHANGELOG not modified since this fixes something introduced in current unreleased version on master.)
