### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Capistrano::Passenger
 
-Adds a task to restart your application after deployment via Capistrano. Supports Passenger versions 5 and lower.
+Adds a task to restart your application after deployment via Capistrano. Supports Passenger versions 6 and lower.
 
 ## Installation
 


### PR DESCRIPTION
The readme states that this gem:

> Supports Passenger versions 5 and lower.

However in the absence of anything better, I installed it in a project using Passenger 6 and it worked flawlessly. So unless I am missing something (and there's every chance that I am), I thought I'd update the readme to reflect this. 