### PR TITLE
Fix version regex

### DIFF
--- a/lib/capistrano/tasks/passenger.cap
+++ b/lib/capistrano/tasks/passenger.cap
@@ -17,7 +17,8 @@ namespace :passenger do
             # Phusion Passenger Enterprise version x.x.x
             # Phusion Passenger x.x.x
             # Phusion Passenger Enterprise x.x.x
-            passenger_version = capture(:passenger, '-v').match(/^Phusion Passenger (Enterprise )?(version )?(.*)$/)[3]
+            # Phusion Passenger(R) x.x.x
+            passenger_version = capture(:passenger, '-v').match(/^Phusion Passenger(\(R\))? (Enterprise )?(version )?(.*)$/)[4]
             restart_with_touch = Gem::Version.new(passenger_version) < Gem::Version.new('4.0.33')
           end
 


### PR DESCRIPTION
After updating from Passenger 6.0.7 to 6.0.8, `passenger -v` prints a version string that the current regex can't match. This patch should fix that.